### PR TITLE
feat: working end-to-end example

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/ArthurSens/demo-weaver-for-dashboarding
 go 1.24.2
 
 require (
-	github.com/grafana/grafana-foundation-sdk/go v0.0.0-20250310114924-e8eb8530bc7c
+	github.com/grafana/grafana-foundation-sdk/go v0.0.0-20250417132802-1b8d81cc23db
 	github.com/prometheus/client_golang v1.23.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
-github.com/grafana/grafana-foundation-sdk/go v0.0.0-20250310114924-e8eb8530bc7c h1:bjn9CW4h4SiSdko3DzDIfGOrxKUqCfJu8ylaMDg33Nc=
-github.com/grafana/grafana-foundation-sdk/go v0.0.0-20250310114924-e8eb8530bc7c/go.mod h1:48EA8jF85SrReYflLa39Sk34b6NpxwJPBwjF3TJgRpE=
+github.com/grafana/grafana-foundation-sdk/go v0.0.0-20250417132802-1b8d81cc23db h1:gyCFYAwGE0K0xO5G9soq/j5DeunZ7dR9h0RHhVV9a44=
+github.com/grafana/grafana-foundation-sdk/go v0.0.0-20250417132802-1b8d81cc23db/go.mod h1:48EA8jF85SrReYflLa39Sk34b6NpxwJPBwjF3TJgRpE=
 github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
 github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=

--- a/templates/registry/dashboards/dashboard-builder.go.j2
+++ b/templates/registry/dashboards/dashboard-builder.go.j2
@@ -1,9 +1,10 @@
-package {{ctx.root_namespace | replace("go", "golang")}}
+package main
 {% set metrics = ctx.metrics %}
 
 // Import the appropriate Grafana Foundation SDK packages
 import (
 	"encoding/json"
+	"fmt"
 	"log"
 
 	"github.com/grafana/grafana-foundation-sdk/go/cog"
@@ -13,9 +14,20 @@ import (
 	"github.com/grafana/grafana-foundation-sdk/go/gauge"
 	{%- endif %}
 	"github.com/grafana/grafana-foundation-sdk/go/prometheus"
+	"github.com/grafana/grafana-foundation-sdk/go/resource"
 	"github.com/grafana/grafana-foundation-sdk/go/timeseries"
 )
 
+func DashboardManifest(dash dashboard.Dashboard) resource.Manifest {
+	return resource.Manifest{
+		ApiVersion: "dashboard.grafana.app/v1beta1",
+		Kind:       "Dashboard",
+		Metadata: resource.Metadata{
+			Name: *dash.Uid,
+		},
+		Spec: dash,
+	}
+}
 
 func main() {
   prometheusDataSourceRef := dashboard.DataSourceRef{
@@ -38,7 +50,7 @@ func main() {
 			Datasource(prometheusDataSourceRef).
 			WithTarget(
 				prometheus.NewDataqueryBuilder().
-					Expr("{{metric.metric_name}}").
+					Expr(`"{"{{metric.metric_name}}"}"`).
 					Range().
 					Format(prometheus.PromQueryFormatTimeSeries).
 					LegendFormat("__auto"),
@@ -51,28 +63,28 @@ func main() {
 			Datasource(prometheusDataSourceRef).
 			WithTarget(
 				prometheus.NewDataqueryBuilder().
-					Expr("histogram_quantile(0.99, rate({{metric.metric_name}}_bucket[$__rate_interval]))").
+					Expr(`histogram_quantile(0.99, rate({"{{metric.metric_name}}_bucket"}[$__rate_interval]))`).
 					Range().
 					Format(prometheus.PromQueryFormatTimeSeries).
 					LegendFormat("p99"),
 			).
 			WithTarget(
 				prometheus.NewDataqueryBuilder().
-					Expr("histogram_quantile(0.90, rate({{metric.metric_name}}_bucket[$__rate_interval]))").
+					Expr(`histogram_quantile(0.90, rate({"{{metric.metric_name}}_bucket"}[$__rate_interval]))`).
 					Range().
 					Format(prometheus.PromQueryFormatTimeSeries).
 					LegendFormat("p90"),
 			).
 			WithTarget(
 				prometheus.NewDataqueryBuilder().
-					Expr("histogram_quantile(0.50, rate({{metric.metric_name}}_bucket[$__rate_interval]))").
+					Expr(`histogram_quantile(0.50, rate({"{{metric.metric_name}}_bucket"}[$__rate_interval]))`).
 					Range().
 					Format(prometheus.PromQueryFormatTimeSeries).
 					LegendFormat("p50"),
 			).
 			WithTarget(
 				prometheus.NewDataqueryBuilder().
-					Expr("rate({{metric.metric_name}}_sum[$__rate_interval]) / rate({{metric.metric_name}}_count[$__rate_interval])").
+					Expr(`rate({"{{metric.metric_name}}_sum"}[$__rate_interval]) / rate({"{{metric.metric_name}}_count"}[$__rate_interval])`).
 					Range().
 					Format(prometheus.PromQueryFormatTimeSeries).
 					LegendFormat("average"),
@@ -85,7 +97,7 @@ func main() {
 			Datasource(prometheusDataSourceRef).
 			WithTarget(
 				prometheus.NewDataqueryBuilder().
-					Expr("sum({{metric.metric_name}})").
+					Expr(`sum({"{{metric.metric_name}}"})`).
 					Range().
 					Format(prometheus.PromQueryFormatTimeSeries).
 					LegendFormat("__auto"),
@@ -98,7 +110,7 @@ func main() {
 			Datasource(prometheusDataSourceRef).
 			WithTarget(
 				prometheus.NewDataqueryBuilder().
-					Expr("rate({{metric.metric_name | snake_case }}[$__rate_interval])").
+					Expr(`rate({"{{metric.metric_name }}"}[$__rate_interval])`).
 					Range().
 					Format(prometheus.PromQueryFormatTimeSeries).
 					LegendFormat("__auto"),
@@ -114,10 +126,9 @@ func main() {
   }
 
   // Output the generated dashboard as JSON
-  dashboardJson, err := json.MarshalIndent(dashboard, "", "  ")
+  dashboardJson, err := json.MarshalIndent(DashboardManifest(dashboard), "", "  ")
   if err != nil {
     log.Fatalf("failed to marshal dashboard: %v", err)
   }
-// CALL Grafana API -X UPDATE DASHBOARD
-  log.Printf(string(dashboardJson))
+  fmt.Println(string(dashboardJson))
 }

--- a/templates/registry/go/vec.go.j2
+++ b/templates/registry/go/vec.go.j2
@@ -97,7 +97,7 @@ func New{{ metric_name }}() {{ metric_name }} {
   }
   return {{metric_name}}{
      {{metric_inst}}Vec: prometheus.New{{metric_inst}}Vec(prometheus.{{metric_inst}}Opts{
-         Name: "{{metric.metric_name | snake_case}}",
+         Name: "{{metric.metric_name }}",
          Help: "{{metric.brief | trim }}",
   }, labels)}
 }


### PR DESCRIPTION
This completes the circle by querying for the correct metrics in the dashboard

Can be tested on top of #8 with:

```
grafanactl resources serve --script 'go run ./generated/dashboards/http' --watch generated/dashboards --script-format json -v --port 8181
```